### PR TITLE
Update 0503.md

### DIFF
--- a/docs/05_fix_performance_issue/0503.md
+++ b/docs/05_fix_performance_issue/0503.md
@@ -48,6 +48,6 @@ In this task, you will update the infrastructure as code Bicep script and create
 
 This is an abbreviated solution. Read the **Description** section above for all of the steps to perform. This solution will not include tasks that you have performed already, such as creating GitHub Issues, commit messages, or pull requests.
 
-- The final Bicep script is [in the solution folder]((https://github.com/microsoft/TechExcel-Accelerate-developer-productivity-with-GitHub-Copilot-and-Dev-Box/blob/main/Solution/Exercise-05/Task-3/main.bicep)). Before looking at this script, try to use GitHub Copilot to generate the changes to your existing `/src/InfrastructureAsCode/main.bicep` file. You may wish to use a prompt such as "Please add in a Basic C0 instance of Azure Cache for Redis." Then, you may wish to compare what GitHub Copilot generated.
+- The final Bicep script is [in the solution folder](https://github.com/microsoft/TechExcel-Accelerate-developer-productivity-with-GitHub-Copilot-and-Dev-Box/blob/main/Solution/Exercise-05/Task-3/main.bicep). Before looking at this script, try to use GitHub Copilot to generate the changes to your existing `/src/InfrastructureAsCode/main.bicep` file. You may wish to use a prompt such as "Please add in a Basic C0 instance of Azure Cache for Redis." Then, you may wish to compare what GitHub Copilot generated.
 
 </details>


### PR DESCRIPTION
Fixed the broken hyper
This pull request includes a minor correction to a markdown file to fix a broken link.

Documentation update:

* [`docs/05_fix_performance_issue/0503.md`](diffhunk://#diff-a2619cebdb8e64899a14f012a79d51022da973c66db7e7356d722649a26af4dcL51-R51): Corrected the link to the final Bicep script by removing an extra pair of parentheses. link